### PR TITLE
Features/5 create motd extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# mgmse - Modern GameSpy Master Server Emulator
-This is a small Laravel project that mimics a GameSpy v1 master server. I'm sorry I couldn't think of a better name!
+# mgmse - Modern Game Master Server Emulator
+Originally this platform was meant to emulate GameSpy v1 master servers. However additional features needed adding, and 
+it eventually grew past that original goal. It can still handle basic GameSpy query/publishing services, 
+but everything else is custom built.
 
 ## Requirements
- - Redis (Memurai works well on Windows!)
+ - Redis
  - PHP 7.4
  - postgres (You shouldn't need this, since we don't store anything in the DB yet, but Laravel will probably complain.)
  - Nginx (If you've enabled the json api feature)

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -3,11 +3,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Server;
-use Illuminate\Http\Request;
+use App\Models\Motd;
+use Response;
 
 class WebController extends Controller
 {
+    protected const MOTD_CACHE_KEY = 'motd_game_id_';
+    protected const MOTD_CACHE_TTL = 300; // 5 minutes in seconds.
+
     public function index()
     {
         return view('welcome');
@@ -16,5 +19,30 @@ class WebController extends Controller
     public function privacy()
     {
         return view('privacy');
+    }
+
+    public function motd($game_id)
+    {
+        // Check if the motd is cached.
+        $key = self::MOTD_CACHE_KEY . $game_id;
+        $content = \Cache::get($key);
+
+        // If the motd isn't cached, then retrieve it from the db.
+        if (!$content) {
+            // Grab the latest motd of a particular game id.
+            $motd = Motd::where('game_id', '=', $game_id)->orderBy('created_at', 'desc')->first();
+            $content = $motd->content ?? '';
+
+            \Cache::put($key, $content, self::MOTD_CACHE_TTL);
+        }
+
+        // Make sure we're sending a text.
+        $headers = [
+            'Content-type' => 'text/plain',
+            'Content-Length' => strlen($content)
+        ];
+
+        // Serve that text file!
+        return Response::make($content, 200, $headers);
     }
 }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -27,6 +27,11 @@ class Game extends Model
 
     public function save(array $options = [])
     {
+        if (\App::runningUnitTests())
+        {
+            return parent::save($options);
+        }
+
         $wantedGame = $this->game_name ?? \Arr::get($options, 'game_name');
 
         $games = \Config::get('games.supported_games', []);

--- a/app/Models/Motd.php
+++ b/app/Models/Motd.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Game;
+
+/**
+ * Message of the day! Or probably month..or year depending on how frequently it gets updated..
+ * This class uses the database.
+ * Class Motd
+ * @property string $content
+ * @package App\Models
+ * @mixin \Eloquent
+ */
+class Motd extends Model
+{
+    protected $table = 'motd';
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'content',
+    ];
+
+    public function Game(): \Illuminate\Database\Eloquent\Relations\HasOne
+    {
+        return $this->hasOne(Game::class);
+    }
+
+}

--- a/database/factories/MotdFactory.php
+++ b/database/factories/MotdFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+
+$factory->define(\App\Models\Motd::class, function (Faker $faker) {
+    return [
+        'content' => $faker->text,
+        'game_id' => function () {
+            return factory(\App\Models\Game::class)->create()->id;
+        },
+    ];
+});

--- a/database/migrations/2020_06_02_030543_create_motd_table.php
+++ b/database/migrations/2020_06_02_030543_create_motd_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMotdTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('motd', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('game_id')->index();
+            $table->mediumText('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('motd');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,3 +13,4 @@
 // Brought this back! Just shows the project's github.
 Route::get('/', 'WebController@index');
 Route::get('/privacy', 'WebController@privacy');
+Route::get('/{game_id}/motd', 'WebController@motd');

--- a/tests/Feature/Http/Controllers/WebControllerTest.php
+++ b/tests/Feature/Http/Controllers/WebControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Game;
+use App\Models\Server;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class WebControllerTest extends TestCase
+{
+
+    /**
+     * Test MOTD is empty when there is no entry in the db
+     */
+    public function testMotdIsEmptyWhenThereIsNoEntry(): void
+    {
+        // Create 1 game
+        $game = factory(\App\Models\Game::class)->create();
+
+        $response = $this->get("/{$game->id}/motd");
+        $response->assertStatus(200);
+
+        $data = $response->getContent();
+
+        // Make sure only the first server shows up!
+        $this->assertEmpty($data);
+    }
+
+    public function testMotdHasContent(): void
+    {
+        // Create 1 game
+        $game = factory(\App\Models\Game::class)->create();
+        $motd = factory(\App\Models\Motd::class)->create(['game_id' => $game->id]);
+
+        $response = $this->get("/{$game->id}/motd");
+        $response->assertStatus(200);
+
+        $data = $response->getContent();
+
+        // Make sure only the first server shows up!
+        $this->assertEquals($motd->content, $data);
+    }
+
+    public function testMotdGetsLatest(): void
+    {
+        // Create 1 game
+        $game         = factory(\App\Models\Game::class)->create();
+
+        // This is not today! So this will never show up.
+        $motdOutdated = factory(\App\Models\Motd::class)->create([
+            'game_id'    => $game->id,
+            'created_at' => Carbon::create(1991, 12, 04),
+        ]);
+
+        // This is today! Which is probably after 1991..
+        $motd         = factory(\App\Models\Motd::class)->create(['game_id' => $game->id]);
+
+        $response = $this->get("/{$game->id}/motd");
+        $response->assertStatus(200);
+
+        $data = $response->getContent();
+
+        // Make sure only the first server shows up!
+        $this->assertEquals($motd->content, $data);
+    }
+
+}


### PR DESCRIPTION
Resolves #5 

Adds MOTD model, route, table, controller and tests. 

Create a new MOTD under a specific game and it'll show up at the route!

As an example:
`http://127.0.0.1:8000/3/motd`

This would show game id 3's motd.

The MOTD is served in plaintext so games can just curl the content.